### PR TITLE
Update Rhai Book reference urls.

### DIFF
--- a/src/reference/vSL/advanced.md
+++ b/src/reference/vSL/advanced.md
@@ -51,13 +51,13 @@ fn my_action2(rcpts) {
 }
 ```
 
-&#9998; | RHAI's function do not capture their external scope except for  functions [(they are "pure")](https://rhai.rs/book/language/functions.html#no-access-to-external-scope). you must pass necessary variables via parameters.
+&#9998; | RHAI's function do not capture their external scope except for  functions [(they are "pure")](https://rhai.rs/book/ref/functions.html#no-access-to-external-scope). you must pass necessary variables via parameters.
 
 ## Importing user defined modules
 
 External modules can be imported in the `main.vsl` file.
 
-RHAI functions are automatically exported. Therefore do not forget to add the `private` keyword for internal functions. Unlike functions, variables are not exported. You must do it manually using the `export` keyword. Check out the [Rhai Book](https://rhai.rs/book/language/modules/export.html) for more information.
+RHAI functions are automatically exported. Therefore do not forget to add the `private` keyword for internal functions. Unlike functions, variables are not exported. You must do it manually using the `export` keyword. Check out the [Rhai Book](https://rhai.rs/book/ref/modules/export.html) for more information.
 
 Example :
 

--- a/src/reference/vSL/functions.md
+++ b/src/reference/vSL/functions.md
@@ -90,7 +90,7 @@ This function dumps in JSON format only the available content at a stage.  The b
 
 ## User-defined actions
 
-Combined actions can be declared using a [RHAI](https://rhai.rs/) function.
+Combined actions can be declared using a [RHAI function](https://rhai.rs/book/ref/functions.html).
 
 ```javascript
 fn my_faccept() {                              

--- a/src/reference/vSL/rules.md
+++ b/src/reference/vSL/rules.md
@@ -45,7 +45,7 @@ rule "check connect" || {
 }
 ```
 
-&#9998; | You can use [String Interpolation](https://rhai.rs/book/language/strings-chars.html#string-interpolation) to inject variables in strings.
+&#9998; | You can use [String Interpolation](https://rhai.rs/book/ref/strings-chars.html#string-interpolation) to inject variables in strings.
 
 The `delegate` directive is different: it also use a smtp service to delegate the email to a third party software:
 


### PR DESCRIPTION
Hi, suggest to update Rhai Book url links to point to the `ref` section instead of `language`.
